### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # qcc_plus - Claude Code CLI 多租户代理服务器
 
+[![Run in Smithery](https://smithery.ai/badge/skills/yxhpy)](https://smithery.ai/skills?ns=yxhpy&utm_source=github&utm_medium=badge)
+
+
 [![Version](https://img.shields.io/badge/version-1.9.4-blue.svg)](https://github.com/yxhpy/qcc_plus/releases/tag/v1.9.4)
 [![npm](https://img.shields.io/npm/v/@qccplus/cli.svg?logo=npm)](https://www.npmjs.com/package/@qccplus/cli)
 [![Go](https://img.shields.io/badge/Go-1.21+-00ADD8?logo=go)](https://go.dev/)


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/yxhpy)](https://smithery.ai/skills?ns=yxhpy&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.